### PR TITLE
Rename package to opendesign/psd-ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ layerPixelData = await layer.composite(true, false);
 layerPixelData = await layer.composite(false);
 ```
 
+## Release process
+
+1. download nix from https://nixos.org/download.html
+2. switch to branch experimental-release
+3. run nix-shell
+4. npm run build
+5. npm run release [version]
+
 ## License
 
 `@webtoon/psd` is released under the [MIT license](https://github.com/webtoon/psd/blob/main/LICENSE).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "webtoon-psd",
+  "name": "psd-ts",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
     "packages/*/"
   ],
   "scripts": {
-    "build": "npm -w @webtoon/psd run build",
+    "build": "npm -w @opendesign/psd-ts run build",
     "clear": "rimraf packages/*/dist/ dist-web/",
     "deploy": "npm -w @webtoon/psd-example-browser -w @webtoon/psd-benchmark run build && gh-pages -d dist-web/",
     "fix": "eslint --fix . && prettier --write .",
     "lint": "eslint . && prettier --check .",
     "prepare": "husky install",
-    "release": "env-cmd npm -w @webtoon/psd run release",
+    "release": "env-cmd npm -w @opendesign/psd-ts run release",
     "start:benchmark": "npm -w @webtoon/psd-benchmark start",
     "start:browser": "npm -w @webtoon/psd-example-browser start",
     "start:node": "npm -w @webtoon/psd-example-node start --watch",

--- a/packages/psd/package.json
+++ b/packages/psd/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@webtoon/psd",
-  "version": "0.3.0",
+  "name": "@opendesign/psd-ts",
+  "version": "0.0.0-experimental",
   "description": "lightweight psd file parser with no dependency written in typescript",
   "homepage": "https://webtoon.github.io/psd",
   "license": "MIT",

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,25 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+with pkgs;
+
+mkShell {
+  buildInputs = [
+    rustup
+    wasm-pack
+    nodejs-18_x
+    # needed for node-canvas
+    pkg-config
+    pixman
+    cairo
+    pango
+    # needed for color converter
+    emscripten
+    bloaty
+    # testing JS
+    nodePackages.http-server
+    nodePackages.prettier
+    nodePackages.indium
+
+    nodePackages.typescript-language-server
+  ];
+}


### PR DESCRIPTION
this way i can actually use published octopus-psd in lambda function. This will be merged into `experimental-release` branch that we will use to publish to @opendesign/psd-ts npm package